### PR TITLE
feat: adapter-vercel should be able to generate sourcemap

### DIFF
--- a/packages/adapter-vercel/README.md
+++ b/packages/adapter-vercel/README.md
@@ -30,7 +30,11 @@ export default {
 
       // if true, will split your app into multiple functions
       // instead of creating a single one for the entire app
-      split: false
+      split: false,
+
+      // same as esbuild sourcemap option
+			// https://esbuild.github.io/api/#sourcemap
+      sourcemap: false
     })
   }
 };

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -1,9 +1,11 @@
 import { Adapter } from '@sveltejs/kit';
+import type { BuildOptions } from 'esbuild';
 
 type Options = {
 	edge?: boolean;
 	external?: string[];
 	split?: boolean;
+	sourcemap?: BuildOptions['sourcemap'];
 };
 
 export default function plugin(options?: Options): Adapter;


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

## Why
This pull-request adds a new option to enable sourcemap for the generated build. This is really important for error monitoring integration. (eg; Sentry in my case).
For now there is no easy way to debug a production app deployed with sveltkit on vercel.

